### PR TITLE
Try bumping nginx for heroku 20 compatibility

### DIFF
--- a/scripts/build_nginx.sh
+++ b/scripts/build_nginx.sh
@@ -9,8 +9,8 @@
 # Once the dyno has is 'up' you can open your browser and navigate
 # this dyno's directory structure to download the nginx binary.
 
-NGINX_VERSION=${NGINX_VERSION-1.16.1}
-PCRE_VERSION=${PCRE_VERSION-8.43}
+NGINX_VERSION=${NGINX_VERSION-1.20.2}
+PCRE_VERSION=${PCRE_VERSION-8.45}
 
 nginx_tarball_url=http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
 pcre_tarball_url=https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VERSION}.tar.gz


### PR DESCRIPTION
Goal is to resolve #1. Versions based on: https://github.com/heroku/heroku-buildpack-nginx/blob/52554faeadf01445e696dfd6737c5a5b9bf95190/scripts/build_nginx\#L7-L8